### PR TITLE
1.5.1 - Lower throws call tree analysis depth to 0

### DIFF
--- a/files/codeStyleSettings.xml
+++ b/files/codeStyleSettings.xml
@@ -13,6 +13,7 @@
           <option name="PHPDOC_BLANK_LINE_BEFORE_TAGS" value="true" />
           <option name="PHPDOC_KEEP_BLANK_LINES" value="true" />
           <option name="PHPDOC_BLANK_LINES_AROUND_PARAMETERS" value="true" />
+          <option name="PHPDOC_THROWS_CALL_TREE_ANALYSIS_DEPTH" value="0" />
           <option name="LOWER_CASE_BOOLEAN_CONST" value="true" />
           <option name="LOWER_CASE_NULL_CONST" value="true" />
           <option name="VARIABLE_NAMING_STYLE" value="CAMEL_CASE" />


### PR DESCRIPTION
By default, recent versions of PHPStorm set the depth for throws call tree analysis to 1. This conflicts with the coding standards provided by `mediact/testing-suite`. A call tree depth of 1 or greater makes it so exceptions thrown by other code called within the current method must be either caught or documented using an `@throws` annotation in the method docblock. The MediaCT coding standards only require exceptions thrown in the current level of the stack to be documented.

![code-style-example](https://user-images.githubusercontent.com/642417/36734180-015abeda-1bd3-11e8-8c58-f84d428dbfde.png)

