### PR TITLE
1.6.0 Add template for PHPUnit test methods, remove constructor test

### DIFF
--- a/files/fileTemplates/code/PHPUnit Test Method.php
+++ b/files/fileTemplates/code/PHPUnit Test Method.php
@@ -1,0 +1,30 @@
+#if (${NAME} == "__construct")
+    #set ($METHOD_NAME = "Constructor")
+#elseif (${NAME} == "__destruct")
+    #set ($METHOD_NAME = "Destructor")
+#elseif (${NAME} == "__toString")
+    #set ($METHOD_NAME = "toString")
+#elseif (${NAME} == "__clone")
+    #set ($METHOD_NAME = "Clone")
+#elseif (${NAME} == "__invoke")
+    #set ($METHOD_NAME = "Invoke")
+#else
+    #set ($METHOD_NAME = ${CAPITALIZED_NAME})
+#end
+/**
+ * @return void
+ *
+ * @covers ::${NAME}
+ */
+public function test$METHOD_NAME(): void
+{
+#if (${NAME} == "__construct")
+    $this->assertInstanceOf(
+        ${TESTED_NAME}::class,
+        new ${TESTED_NAME}()
+    );
+#else
+    $subject = new ${TESTED_NAME}();
+    $subject->${NAME}();
+#end
+}

--- a/files/fileTemplates/internal/PHPUnit Test.php
+++ b/files/fileTemplates/internal/PHPUnit Test.php
@@ -13,16 +13,4 @@ use ${TESTED_NAMESPACE}\\${TESTED_NAME};
  */
 class ${NAME} extends TestCase
 {
-    /**
-     * @return void
-     *
-     * @covers ::__construct
-     */
-    public function testConstructor(): void
-    {
-        $this->assertInstanceOf(
-            ${TESTED_NAME}::class,
-            new ${TESTED_NAME}()
-        );
-    }
 }


### PR DESCRIPTION
PhpStorm 2017.3 supports templates for PHPUnit test methods. The methods
can be selected when creating a new test. Because the constructor can
now be selected it has been removed from the standard file template.

![screenshot from 2018-03-22 11-47-07](https://user-images.githubusercontent.com/2527109/37750236-f352aedc-2dc6-11e8-9da2-a5851628cfb8.png)
![screenshot from 2018-03-22 11-48-08](https://user-images.githubusercontent.com/2527109/37750248-fa81878c-2dc6-11e8-9b21-0fadf993488e.png)
