### PR TITLE
1.6.1 Indent arrays in YAML

### DIFF
--- a/files/codeStyleSettings.xml
+++ b/files/codeStyleSettings.xml
@@ -25,6 +25,9 @@
           <option name="XML_TEXT_WRAP" value="0" />
           <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
         </XML>
+        <yaml>
+          <option name="INDENT_SEQUENCE_VALUE" value="true" />
+        </yaml>
         <codeStyleSettings language="JSON">
           <indentOptions>
             <option name="INDENT_SIZE" value="2" />

--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -147,6 +147,7 @@ class Filesystem implements FilesystemInterface
             if ($fileInfo->isDir()) {
                 continue;
             }
+
             $files[] = preg_replace(
                 sprintf('/^%s/', preg_quote($this->root, '/')),
                 '',

--- a/tests/FilesystemTest.php
+++ b/tests/FilesystemTest.php
@@ -220,9 +220,9 @@ class FilesystemTest extends TestCase
     }
 
     /**
-     * @param array      $files
-     * @param string     $path
-     * @param array      $expected
+     * @param array  $files
+     * @param string $path
+     * @param array  $expected
      *
      * @return void
      *


### PR DESCRIPTION
The code style settings for YAML have been changed to indent arrays.

Before:

```
foo:
- bar
- baz
```

After:

```
foo:
  - bar
  - baz
```