### PR TITLE
Bump version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
             "email": "contact@mediact.nl"
         }
     ],
-    "version": "2.0.2",
+    "version": "2.0.3",
     "require": {
         "php": "^7.1",
         "composer-plugin-api": "^1.0"


### PR DESCRIPTION
A version is needed because the package has a circular dependency on
mediact/testing-suite. That package should become a meta package to be
able to solve the circularity.