### PR TITLE
 Enable strict types for all internal PHP file templates

### DIFF
--- a/files/fileTemplates/includes/PHP Property Doc Comment.php
+++ b/files/fileTemplates/includes/PHP Property Doc Comment.php
@@ -1,0 +1,1 @@
+/** @var ${TYPE_HINT} */

--- a/files/fileTemplates/internal/PHP Class.php
+++ b/files/fileTemplates/internal/PHP Class.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 #parse("PHP File Header")
 
 #if (${NAMESPACE})

--- a/files/fileTemplates/internal/PHP File.php
+++ b/files/fileTemplates/internal/PHP File.php
@@ -1,2 +1,2 @@
-<?php
+<?php declare(strict_types=1);
 #parse("PHP File Header")

--- a/files/fileTemplates/internal/PHP Interface.php
+++ b/files/fileTemplates/internal/PHP Interface.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 #parse("PHP File Header")
 
 #if (${NAMESPACE})

--- a/files/fileTemplates/internal/PHP Trait.php
+++ b/files/fileTemplates/internal/PHP Trait.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 #parse("PHP File Header")
 
 #if (${NAMESPACE})

--- a/files/fileTemplates/internal/PHPUnit Test.php
+++ b/files/fileTemplates/internal/PHPUnit Test.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 #parse("PHP File Header")
 
 #if (${NAMESPACE})


### PR DESCRIPTION
- Enable strict types for all internal PHP file templates
- Add a property doc template
