### PR TITLE
Format declare according to PSR 12

### DIFF
--- a/files/fileTemplates/internal/PHP Class.php
+++ b/files/fileTemplates/internal/PHP Class.php
@@ -1,5 +1,8 @@
-<?php declare(strict_types=1);
+<?php
 #parse("PHP File Header")
+
+
+declare(strict_types=1);
 
 #if (${NAMESPACE})
 namespace ${NAMESPACE};

--- a/files/fileTemplates/internal/PHP File.php
+++ b/files/fileTemplates/internal/PHP File.php
@@ -1,2 +1,5 @@
-<?php declare(strict_types=1);
+<?php
 #parse("PHP File Header")
+
+
+declare(strict_types=1);

--- a/files/fileTemplates/internal/PHP Interface.php
+++ b/files/fileTemplates/internal/PHP Interface.php
@@ -1,5 +1,8 @@
-<?php declare(strict_types=1);
+<?php
 #parse("PHP File Header")
+
+
+declare(strict_types=1);
 
 #if (${NAMESPACE})
 namespace ${NAMESPACE};

--- a/files/fileTemplates/internal/PHP Trait.php
+++ b/files/fileTemplates/internal/PHP Trait.php
@@ -1,5 +1,8 @@
-<?php declare(strict_types=1);
+<?php
 #parse("PHP File Header")
+
+
+declare(strict_types=1);
 
 #if (${NAMESPACE})
 namespace ${NAMESPACE};

--- a/files/fileTemplates/internal/PHPUnit Test.php
+++ b/files/fileTemplates/internal/PHPUnit Test.php
@@ -1,5 +1,8 @@
-<?php declare(strict_types=1);
+<?php
 #parse("PHP File Header")
+
+
+declare(strict_types=1);
 
 #if (${NAMESPACE})
 namespace ${NAMESPACE};


### PR DESCRIPTION
According to PSR12 the order of blocks in a PHP file is:

- Opening <?php tag.
- File-level docblock.
- One or more declare statements.
- The namespace declaration of the file.
- One or more class-based use import statements.
- One or more function-based use import statements.
- One or more constant-based use import statements.
- The remainder of the code in the file.